### PR TITLE
Fixed crash

### DIFF
--- a/bazinga/__init__.py
+++ b/bazinga/__init__.py
@@ -156,6 +156,8 @@ class Bazinga(Plugin):
         # even if a module is passed as argument to Nose
         try:
             source = inspect.getsourcefile(cls)
+            if source is None:
+                return None
         except TypeError:
             return None
 


### PR DESCRIPTION
Hello,

just stumbled upon a crash of Bazinga when it tried to get the source of the "Webtest" module. inspect somehow returned None, but it wasn't checked, so open(None) crashed the whole testsuite.

Running it now for the first time. :)

Christoph
